### PR TITLE
Nav Stack Separation

### DIFF
--- a/DeadByTwilight/src/navigators/AuthStack.tsx
+++ b/DeadByTwilight/src/navigators/AuthStack.tsx
@@ -2,12 +2,10 @@ import * as React from 'react';
 
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {RegisterScreen, LoginScreen} from '../screens';
-import {GameStack} from './GameStack';
 
 export type AuthStackParamList = {
   Register: undefined;
   Login: undefined;
-  GameStack: undefined;
 };
 
 const Stack = createNativeStackNavigator<AuthStackParamList>();
@@ -20,7 +18,6 @@ export const AuthStack = () => {
       initialRouteName="Login">
       <Stack.Screen name="Login" component={LoginScreen} />
       <Stack.Screen name="Register" component={RegisterScreen} />
-      <Stack.Screen name="GameStack" component={GameStack} />
     </Stack.Navigator>
   );
 };

--- a/DeadByTwilight/src/navigators/DefaultStack.tsx
+++ b/DeadByTwilight/src/navigators/DefaultStack.tsx
@@ -15,12 +15,11 @@ const Stack = createNativeStackNavigator<DefaultStackParamList>();
 
 export const DefaultStack = () => {
   const {currentUser} = useCurrentUser();
-  const AppStack =
-    currentUser && currentUser.displayName ? (
-      <Stack.Screen name="App" component={GameStack} />
-    ) : (
-      <Stack.Screen name="App" component={AuthStack} />
-    );
+  const AppStack = !!currentUser ? (
+    <Stack.Screen name="App" component={GameStack} />
+  ) : (
+    <Stack.Screen name="App" component={AuthStack} />
+  );
   return (
     <Stack.Navigator
       screenOptions={{

--- a/DeadByTwilight/src/navigators/DefaultStack.tsx
+++ b/DeadByTwilight/src/navigators/DefaultStack.tsx
@@ -4,25 +4,31 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {TitleScreen} from '../screens';
 import {GameStack} from './GameStack';
 import {AuthStack} from './AuthStack';
+import {useCurrentUser} from '../hooks';
 
 export type DefaultStackParamList = {
   Title: undefined;
-  GameStack: undefined;
-  AuthStack: undefined;
+  App: undefined;
 };
 
 const Stack = createNativeStackNavigator<DefaultStackParamList>();
 
 export const DefaultStack = () => {
+  const {currentUser} = useCurrentUser();
+  const AppStack =
+    currentUser && currentUser.displayName ? (
+      <Stack.Screen name="App" component={GameStack} />
+    ) : (
+      <Stack.Screen name="App" component={AuthStack} />
+    );
   return (
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
       }}
-      initialRouteName="Title">
+      initialRouteName={'Title'}>
       <Stack.Screen name="Title" component={TitleScreen} />
-      <Stack.Screen name="GameStack" component={GameStack} />
-      <Stack.Screen name="AuthStack" component={AuthStack} />
+      {AppStack}
     </Stack.Navigator>
   );
 };

--- a/DeadByTwilight/src/navigators/GameStack.tsx
+++ b/DeadByTwilight/src/navigators/GameStack.tsx
@@ -1,20 +1,13 @@
 import * as React from 'react';
 
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import {
-  CreateOrJoinScreen,
-  GameScreen,
-  LobbyScreen,
-  PostGameScreen,
-} from '../screens';
+import {GameScreen, LobbyScreen, PostGameScreen} from '../screens';
 import {GameContext, GameDispatchContext} from '../GameContext';
 import {gamestateReducer, initialState} from '../gamestateReducer';
 import {GameChannelProvider} from '../hooks';
-import {AuthStack} from './AuthStack';
 import {HomeTabs} from './HomeTabs';
 
 export type GameStackParamList = {
-  AuthStack: undefined;
   HomeTabs: undefined;
   Lobby: {didCreateRoom: boolean};
   Game: undefined;
@@ -35,7 +28,6 @@ export const GameStack = () => {
               headerShown: false,
             }}
             initialRouteName="HomeTabs">
-            <Stack.Screen name="AuthStack" component={AuthStack} />
             <Stack.Screen name="HomeTabs" component={HomeTabs} />
             <Stack.Screen
               name="Lobby"

--- a/DeadByTwilight/src/screens/CreateOrJoinScreen.tsx
+++ b/DeadByTwilight/src/screens/CreateOrJoinScreen.tsx
@@ -24,7 +24,9 @@ export const CreateOrJoinScreen: React.FC<NestedTabProps> = ({navigation}) => {
   );
   const {currentUser} = useCurrentUser();
   const {navigate, jumpTo} = navigation;
-  const name = currentUser?.displayName || 'Anon';
+  const welcomeLabel = currentUser?.displayName
+    ? `Welcome back, ${currentUser.displayName}!`
+    : 'Welcome to DBT';
 
   useGameChannel(id);
 
@@ -56,10 +58,7 @@ export const CreateOrJoinScreen: React.FC<NestedTabProps> = ({navigation}) => {
       <View style={{...styles.wrapper, ...global.screenWrapper}}>
         <View style={{top: 60}}>
           <Text style={{...styles.text, textAlign: 'center', color: 'white'}}>
-            {'Welcome, '}
-          </Text>
-          <Text style={{...styles.text, textAlign: 'center', color: 'white'}}>
-            {name}!
+            {welcomeLabel}
           </Text>
         </View>
         <ColumnWrapper
@@ -81,7 +80,7 @@ export const CreateOrJoinScreen: React.FC<NestedTabProps> = ({navigation}) => {
             </Text>
             <View style={{...styles.button}}>
               <Button
-                disabled={!name || !currentUser?.emailVerified}
+                disabled={!currentUser?.emailVerified}
                 onPress={onPressCreate}
                 color="white"
                 title="Create Game"
@@ -89,7 +88,7 @@ export const CreateOrJoinScreen: React.FC<NestedTabProps> = ({navigation}) => {
             </View>
             <View style={{...styles.button}}>
               <Button
-                disabled={!name || !currentUser?.emailVerified}
+                disabled={!currentUser?.emailVerified}
                 onPress={onPressJoin}
                 color="white"
                 title="Join Game"
@@ -104,7 +103,6 @@ export const CreateOrJoinScreen: React.FC<NestedTabProps> = ({navigation}) => {
             </View>
             <View style={{...styles.button}}>
               <Button
-                disabled={!name}
                 onPress={async () => await auth.signOut()}
                 color="white"
                 title="Sign Out"

--- a/DeadByTwilight/src/screens/CreateOrJoinScreen.tsx
+++ b/DeadByTwilight/src/screens/CreateOrJoinScreen.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-inline-styles */
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {View, StyleSheet, Button, Text} from 'react-native';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {GameStackParamList} from '../navigators';
@@ -30,10 +30,6 @@ export const CreateOrJoinScreen: React.FC<NestedTabProps> = ({navigation}) => {
 
   const [showJoinAlert, setShowJoinAlert] = useState(false);
   const [showCreateRoom, setShowCreateRoom] = useState(false);
-
-  useEffect(() => {
-    if (!currentUser) navigate('AuthStack');
-  }, [currentUser]);
 
   const onPressCreate = () => {
     setId(shortid.generate());

--- a/DeadByTwilight/src/screens/TitleScreen.tsx
+++ b/DeadByTwilight/src/screens/TitleScreen.tsx
@@ -23,8 +23,6 @@ export const TitleScreen: React.FC<
     fadeIn();
   }, []);
 
-  const nextStack = isLoggedIn ? 'GameStack' : 'AuthStack';
-
   return (
     <>
       <View style={{...styles.wrapper, ...global.screenWrapper}}>
@@ -36,7 +34,7 @@ export const TitleScreen: React.FC<
         </View>
         <View style={{backgroundColor: '#841584', width: '50%'}}>
           <Button
-            onPress={() => navigation.navigate(nextStack)}
+            onPress={() => navigation.navigate('App')}
             color="#fff"
             title="get started"
           />

--- a/DeadByTwilight/src/screens/authScreens/LoginScreen.tsx
+++ b/DeadByTwilight/src/screens/authScreens/LoginScreen.tsx
@@ -8,7 +8,7 @@ import {global} from '../../styles';
 import {ErrorMessage, Formik} from 'formik';
 import {auth} from '../../firebase/config';
 import {signInWithEmailAndPassword} from 'firebase/auth';
-import {useContext, useEffect, useState} from 'react';
+import {useState} from 'react';
 import {loginSchema} from './helpers';
 import {
   ErrorLabel,
@@ -17,13 +17,10 @@ import {
 } from '../../components';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {AuthStackParamList} from '../../navigators';
-import {CurrentUserContext} from '../../CurrentUserContext';
 
 export const LoginScreen: React.FC<
   NativeStackScreenProps<AuthStackParamList, 'Login'>
 > = ({navigation}) => {
-  const {navigate} = navigation;
-  const {currentUser} = useContext(CurrentUserContext);
   const [loginError, setLoginError] = useState('');
   const [showForgot, setShowForgot] = useState(false);
   const handleLogin = async (email: string, password: string) => {
@@ -35,10 +32,6 @@ export const LoginScreen: React.FC<
         setLoginError(error);
       });
   };
-
-  useEffect(() => {
-    if (currentUser) navigate('GameStack');
-  }, [currentUser]);
 
   return (
     <>

--- a/DeadByTwilight/src/screens/authScreens/RegisterScreen.tsx
+++ b/DeadByTwilight/src/screens/authScreens/RegisterScreen.tsx
@@ -12,7 +12,7 @@ import {
   sendEmailVerification,
   updateProfile,
 } from 'firebase/auth';
-import {useContext, useEffect, useState} from 'react';
+import {useContext, useState} from 'react';
 import {registerSchema} from './helpers';
 import {ErrorLabel, StyledRegisterInput} from '../../components';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
@@ -42,10 +42,6 @@ export const RegisterScreen: React.FC<
         console.log(errorMessage);
       });
   };
-
-  useEffect(() => {
-    if (currentUser) navigate('GameStack');
-  }, [currentUser]);
 
   return (
     <View


### PR DESCRIPTION
1. Update the stacks for better separation. Currently the different stacks contain one another, which causes a) a require cycle (` Authstack` <==> `Gamestack`) and b) the ability to gesture back to auth from game stack.
This is undesirable because once the user is logged in given the current setup, the _Authstack remains mounted_  . We do not want the `Authstack` to be mounted if the user is logged in.

2. Change greeting so stale "Anon" label is not used during the initial greeting.